### PR TITLE
Show a default image for users (fixes #12)

### DIFF
--- a/js/stalk.js
+++ b/js/stalk.js
@@ -57,6 +57,9 @@ function updateResults() {
 					.append($("<img></img>")
 					.attr("src", e.picture)
 					.attr("id", e.username)
+          .on("error", function(){
+            $(this).attr("src", "/imgs/duck.jpg").off("error");
+          })
 				);
 			});
 
@@ -112,7 +115,10 @@ function makeHighlight(uid) {
 
 	var img = $("<img>")
 				.attr("src", usr.picture)
-				.attr("data-uid", uid);
+				.attr("data-uid", uid)
+        .on("error", function(){
+          $(this).attr("src", "/imgs/duck.jpg").off("error");
+        });
 
 	highlight
 	.append(img)


### PR DESCRIPTION
When the loading of a user image fails we instead show the default user
image as added in a previous PR.