### PR TITLE
Show a default country flag (fixes #13)

### DIFF
--- a/js/stalk.js
+++ b/js/stalk.js
@@ -116,7 +116,9 @@ function makeHighlight(uid) {
 
 	highlight
 	.append(img)
-	.append($("<img>").attr("src", usr.flag).attr("class", "flag"))
+	.append($("<img>").attr("src", usr.flag).attr("class", "flag").on("error", function(){
+    $(this).attr("src", "/imgs/NoCountry.png").off("error"); 
+  }))
 	.append(getHighlightDetails(usr))
 	.css(getHighlightPosition(anchor));
 


### PR DESCRIPTION
If the loading of a country flag fails, we instead show the default
country image which was added in a previous PR. 